### PR TITLE
fixed Issue9

### DIFF
--- a/R/crm_text.R
+++ b/R/crm_text.R
@@ -161,8 +161,9 @@
 #' }
 
 crm_text <- function(url, type='xml', path = cr_cache_path(), overwrite = TRUE,
-                       read=TRUE, verbose=TRUE, cache=TRUE, ...) {
-
+                       read=TRUE, verbose=TRUE, cache=TRUE,
+                       overwriteUnspecified=FALSE, ...) {
+  url <- maybe_overwrite_unspecified(overwriteUnspecified,url,type)
   auth <- cr_auth(url, type)
   switch( pick_type(type, url),
           xml = getTEXT(get_url(url, 'xml'), type, auth, ...),
@@ -186,7 +187,8 @@ get_url <- function(a, b){
 #' @export
 #' @rdname crm_text
 crm_plain <- function(url, path = cr_cache_path(), overwrite = TRUE, read=TRUE,
-                        verbose=TRUE, ...) {
+                        verbose=TRUE, overwriteUnspecified=FALSE, ...) {
+  url <- maybe_overwrite_unspecified(overwriteUnspecified,url,"plain")
   if (is.null(url$plain[[1]])) {
     stop("no plain text link found", call. = FALSE)
   }
@@ -196,7 +198,8 @@ crm_plain <- function(url, path = cr_cache_path(), overwrite = TRUE, read=TRUE,
 #' @export
 #' @rdname crm_text
 crm_xml <- function(url, path = cr_cache_path(), overwrite = TRUE, read=TRUE,
-                      verbose=TRUE, ...) {
+                      verbose=TRUE, overwriteUnspecified=FALSE, ...) {
+  url <- maybe_overwrite_unspecified(overwriteUnspecified,url,"xml")
   if (is.null(url$xml[[1]])) {
     stop("no xml link found", call. = FALSE)
   }
@@ -206,7 +209,8 @@ crm_xml <- function(url, path = cr_cache_path(), overwrite = TRUE, read=TRUE,
 #' @export
 #' @rdname crm_text
 crm_pdf <- function(url, path = cr_cache_path(), overwrite = TRUE, read=TRUE,
-                      cache=FALSE, verbose=TRUE, ...) {
+                      cache=FALSE, verbose=TRUE, overwriteUnspecified=FALSE, ...) {
+  url <- maybe_overwrite_unspecified(overwriteUnspecified,url,"pdf")
   if (is.null(url$pdf[[1]])) {
     stop("no pdf link found", call. = FALSE)
   }
@@ -319,4 +323,11 @@ getPDF <- function(url, path, auth, overwrite, type, read, verbose,
   } else {
     filepath
   }
+}
+maybe_overwrite_unspecified <- function(overwriteUnspecified, url,type) {
+  if(overwriteUnspecified) {
+    url <- setNames(url, type)
+    attr(url, "type") <- type
+  }
+url
 }

--- a/R/crm_text.R
+++ b/R/crm_text.R
@@ -19,9 +19,9 @@
 #' you want to use cached version so that you don't have to download the file
 #' again. The steps of extracting and reading into R still have to be performed
 #' when \code{cache=TRUE}. Default: \code{TRUE}
-#' @param overwriteUnspecified (logical) Sometimes the crossref API returns mime type 'unspecified'
-#' for the full text links (for some Wiley dois for example). This parameter overrides the
-#' mime type to be \emph{'type}.'
+#' @param overwriteUnspecified (logical) Sometimes the crossref API returns mime type
+#' 'unspecified' for the full text links (for some Wiley dois for example).
+#' This parameter overrides the mime type to be \code{type}.
 #' @param ... Named parameters passed on to \code{\link[httr]{GET}}
 #' @details Note that \code{\link{crm_text}},
 #' \code{\link{crm_pdf}}, \code{\link{crm_xml}}, \code{\link{crm_plain}}
@@ -128,7 +128,7 @@
 #' # res <- list()
 #' # for (i in seq_along(dois)) {
 #' # tmp <- crm_links(dois[i], "all")
-#' # res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
+#' # res[[i]] <- crm_text(tmp, type = "pdf", cache=F, overwriteUnspecified=T)
 #' # }
 #' # res
 #'
@@ -153,7 +153,7 @@
 #' # res <- list()
 #' # for (i in seq_along(dois)) {
 #' #   tmp <- crm_links(dois[i], "all")
-#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
+#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=F, overwriteUnspecified=T)
 #' # }
 #' }
 

--- a/R/crm_text.R
+++ b/R/crm_text.R
@@ -19,6 +19,9 @@
 #' you want to use cached version so that you don't have to download the file
 #' again. The steps of extracting and reading into R still have to be performed
 #' when \code{cache=TRUE}. Default: \code{TRUE}
+#' @param overwriteUnspecified (logical) Sometimes the crossref API returns mime type 'unspecified'
+#' for the full text links (for some Wiley dois for example). This parameter overrides the
+#' mime type to be \emph{'type}.'
 #' @param ... Named parameters passed on to \code{\link[httr]{GET}}
 #' @details Note that \code{\link{crm_text}},
 #' \code{\link{crm_pdf}}, \code{\link{crm_xml}}, \code{\link{crm_plain}}
@@ -124,10 +127,8 @@
 #' dois <- out$data$DOI[1:10]
 #' # res <- list()
 #' # for (i in seq_along(dois)) {
-#' #   tmp <- crm_links(dois[i], "all")
-#' #   tmp <- setNames(tmp, "pdf")
-#' #   attr(tmp, "type") <- "pdf"
-#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+#' # tmp <- crm_links(dois[i], "all")
+#' # res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 #' # }
 #' # res
 #'
@@ -140,9 +141,7 @@
 #' # res <- list()
 #' # for (i in seq_along(dois)) {
 #' #   tmp <- crm_links(dois[i], "all")
-#' #   tmp <- setNames(tmp, "pdf")
-#' #   attr(tmp, "type") <- "pdf"
-#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 #' # }
 #' # res
 #'
@@ -154,9 +153,7 @@
 #' # res <- list()
 #' # for (i in seq_along(dois)) {
 #' #   tmp <- crm_links(dois[i], "all")
-#' #   tmp <- setNames(tmp, "pdf")
-#' #   attr(tmp, "type") <- "pdf"
-#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+#' #   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 #' # }
 #' }
 

--- a/man/crm_text.Rd
+++ b/man/crm_text.Rd
@@ -46,9 +46,9 @@ you want to use cached version so that you don't have to download the file
 again. The steps of extracting and reading into R still have to be performed
 when \code{cache=TRUE}. Default: \code{TRUE}}
 
-\item{overwriteUnspecified}{(logical) Sometimes the crossref API returns mime type 'unspecified'
-for the full text links (for some Wiley dois for example). This parameter overrides the
-mime type to be \emph{'type}.'}
+\item{overwriteUnspecified}{(logical) Sometimes the crossref API returns mime type
+'unspecified' for the full text links (for some Wiley dois for example).
+This parameter overrides the mime type to be \code{type}.}
 
 \item{...}{Named parameters passed on to \code{\link[httr]{GET}}}
 }
@@ -163,7 +163,7 @@ dois <- out$data$DOI[1:10]
 # res <- list()
 # for (i in seq_along(dois)) {
 # tmp <- crm_links(dois[i], "all")
-# res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
+# res[[i]] <- crm_text(tmp, type = "pdf", cache=F, overwriteUnspecified=T)
 # }
 # res
 
@@ -188,7 +188,7 @@ dois <- out$data$DOI[1:10]
 # res <- list()
 # for (i in seq_along(dois)) {
 #   tmp <- crm_links(dois[i], "all")
-#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
+#   res[[i]] <- crm_text(tmp, type = "pdf", cache=F, overwriteUnspecified=T)
 # }
 }
 }

--- a/man/crm_text.Rd
+++ b/man/crm_text.Rd
@@ -8,16 +8,17 @@
 \title{Get full text from a DOI}
 \usage{
 crm_text(url, type = "xml", path = cr_cache_path(), overwrite = TRUE,
-  read = TRUE, verbose = TRUE, cache = TRUE, ...)
+  read = TRUE, verbose = TRUE, cache = TRUE,
+  overwriteUnspecified = FALSE, ...)
 
 crm_plain(url, path = cr_cache_path(), overwrite = TRUE, read = TRUE,
-  verbose = TRUE, ...)
+  verbose = TRUE, overwriteUnspecified = FALSE, ...)
 
 crm_xml(url, path = cr_cache_path(), overwrite = TRUE, read = TRUE,
-  verbose = TRUE, ...)
+  verbose = TRUE, overwriteUnspecified = FALSE, ...)
 
 crm_pdf(url, path = cr_cache_path(), overwrite = TRUE, read = TRUE,
-  cache = FALSE, verbose = TRUE, ...)
+  cache = FALSE, verbose = TRUE, overwriteUnspecified = FALSE, ...)
 }
 \arguments{
 \item{url}{(character) A URL.}
@@ -25,7 +26,7 @@ crm_pdf(url, path = cr_cache_path(), overwrite = TRUE, read = TRUE,
 \item{type}{(character) One of xml, plain, pdf, or all}
 
 \item{path}{(character) Path to store pdfs in. By default we use
-\code{paste0(rappdirs::user_cache_dir(), "/crossref")}, but you can
+\code{paste0(rappdirs::user_cache_dir(), "/crminer")}, but you can
 set this directory to something different. Ignored unless getting
 pdf}
 
@@ -44,6 +45,10 @@ your machine locally, so this doesn't affect that. This only states whether
 you want to use cached version so that you don't have to download the file
 again. The steps of extracting and reading into R still have to be performed
 when \code{cache=TRUE}. Default: \code{TRUE}}
+
+\item{overwriteUnspecified}{(logical) Sometimes the crossref API returns mime type 'unspecified'
+for the full text links (for some Wiley dois for example). This parameter overrides the
+mime type to be \emph{'type}.'}
 
 \item{...}{Named parameters passed on to \code{\link[httr]{GET}}}
 }
@@ -157,10 +162,8 @@ out <- cr_members(311, filter=c(has_full_text = TRUE,
 dois <- out$data$DOI[1:10]
 # res <- list()
 # for (i in seq_along(dois)) {
-#   tmp <- crm_links(dois[i], "all")
-#   tmp <- setNames(tmp, "pdf")
-#   attr(tmp[[1]], "type") <- "pdf"
-#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+# tmp <- crm_links(dois[i], "all")
+# res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 # }
 # res
 
@@ -173,9 +176,7 @@ dois <- out$data$DOI[1:10]
 # res <- list()
 # for (i in seq_along(dois)) {
 #   tmp <- crm_links(dois[i], "all")
-#   tmp <- setNames(tmp, "pdf")
-#   attr(tmp[[1]], "type") <- "pdf"
-#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 # }
 # res
 
@@ -187,9 +188,7 @@ dois <- out$data$DOI[1:10]
 # res <- list()
 # for (i in seq_along(dois)) {
 #   tmp <- crm_links(dois[i], "all")
-#   tmp <- setNames(tmp, "pdf")
-#   attr(tmp[[1]], "type") <- "pdf"
-#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE)
+#   res[[i]] <- crm_text(tmp, type = "pdf", cache=FALSE, overwriteUnspecified=T)
 # }
 }
 }

--- a/tests/testthat/test-crm_pdf.R
+++ b/tests/testthat/test-crm_pdf.R
@@ -1,13 +1,15 @@
 context("crm_pdf")
 
-test_that("crm_pdf works for 'unspecified'",{
+test_that("crm_pdf works for 'unspecified' =T",{
+  skip_if_not(Sys.getenv("CROSSREF_TDM")!="",
+              "Needs 'Sys.setenv(CROSSREF_TDM = \"your-key\")' to be set.")
   links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
 
   res <- crm_pdf(links,overwriteUnspecified = T)
   expect_equal(res$info$pages,11)
 })
 
-test_that("crm_pdf works for 'unspecified'",{
+test_that("crm_pdf fails for 'unspecified' = F",{
   links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
 
   expect_error(crm_pdf(links,overwriteUnspecified = F),

--- a/tests/testthat/test-crm_pdf.R
+++ b/tests/testthat/test-crm_pdf.R
@@ -1,0 +1,16 @@
+context("crm_pdf")
+
+test_that("crm_pdf works for 'unspecified'",{
+  links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
+
+  res <- crm_pdf(links,overwriteUnspecified = T)
+  expect_equal(res$info$pages,11)
+})
+
+test_that("crm_pdf works for 'unspecified'",{
+  links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
+
+  expect_error(crm_pdf(links,overwriteUnspecified = F),
+              "no pdf link found")
+
+})

--- a/tests/testthat/test-crm_text.R
+++ b/tests/testthat/test-crm_text.R
@@ -38,14 +38,16 @@ test_that("crm_text fails correctly", {
   expect_error(crm_text(links, type = "adfasf"), "'arg' should be one of")
 })
 
-test_that("crm_text with pdf works for 'unspecified'",{
+test_that("crm_text with pdf works for 'unspecified'=T",{
+  skip_if_not(Sys.getenv("CROSSREF_TDM")!="",
+              "Needs 'Sys.setenv(CROSSREF_TDM = \"your-key\")' to be set.")
   links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
 
   res <- crm_text(links,type="pdf",overwriteUnspecified = T)
   expect_equal(res$info$pages,11)
 })
 
-test_that("crm_text with pdf fails for 'unspecified'",{
+test_that("crm_text with pdf fails for 'unspecified'=F",{
   links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
 
   expect_error(crm_text(links,type="pdf",overwriteUnspecified = F),

--- a/tests/testthat/test-crm_text.R
+++ b/tests/testthat/test-crm_text.R
@@ -37,3 +37,18 @@ test_that("crm_text fails correctly", {
   links <- crm_links("10.1155/mbd.1994.183", "all")
   expect_error(crm_text(links, type = "adfasf"), "'arg' should be one of")
 })
+
+test_that("crm_text with pdf works for 'unspecified'",{
+  links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
+
+  res <- crm_text(links,type="pdf",overwriteUnspecified = T)
+  expect_equal(res$info$pages,11)
+})
+
+test_that("crm_text with pdf fails for 'unspecified'",{
+  links <- crm_links("10.2903/j.efsa.2014.3550",type = "all")
+
+  expect_error(crm_text(links,type="pdf",overwriteUnspecified = F),
+              "Chosen type not available in links")
+})
+


### PR DESCRIPTION
My idea was to introduce an extra parameter 'overwriteUnspecified=FALSE' to all fulltext methods.

If set to FALSE, the behaviour is the same as before.

If set tto TRUE, it overrrides the 'type' of the url and sets it to the 'type' of the method.
So it does inside, wha was docuemnted to do outside the method.

I added some tests, but they need a valid Wiley CROSSREF_TDM.